### PR TITLE
update core_concepts.md: create deployment task

### DIFF
--- a/core_concepts.md
+++ b/core_concepts.md
@@ -297,14 +297,9 @@ kubectl get componentstatus
 <details><summary>show</summary>
 <p>
 
-```bash
-# create a  YAML template with this command
-kubectl run nginx --image=nginx --replicas=2 --dry-run -o yaml > deploy.yaml
-# see it
-cat deploy.yaml
-```
-
 ```YAML
+# create a deployment object using this YAML template with the following command
+cat <<EOF | kubectl apply -f -
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -329,9 +324,12 @@ spec:
         name: nginx
         resources: {}
 status: {}
+EOF
 ```
 
 ```bash
+# create the file deploy.yaml with the content above
+vim deploy.yaml
 # create the deployment
 kubectl apply -f deploy.yaml
 # get verbose output of deployment YAML


### PR DESCRIPTION
> Create a deployment with two replica pods from YAML

The task above is outdated.



> kubectl run nginx --image=nginx --replicas=2 --dry-run -o yaml > deploy.yaml

The previous command is not working anymore as described on latest version of kubernetes and it creates a single pod instead of a deployment with two replicas