### PR TITLE
--export parameter deprecated

### DIFF
--- a/core_concepts.md
+++ b/core_concepts.md
@@ -219,18 +219,6 @@ kubectl logs nginx
 </p>
 </details>
 
-### Output a pod's YAML without cluster specific information
-
-<details><summary>show</summary>
-<p>
-
-```bash
-kubectl get pod my-pod -o yaml --export
-```
-
-</p>
-</details>
-
 ### List all nodes in the cluster
 
 <details><summary>show</summary>


### PR DESCRIPTION
Output a pod's YAML without cluster specific information

Problem:
--export parameter doesn't work

Reason:
Deprecated due to inconsistency.

Check this:
[Stackoverflow thread reply about this](https://stackoverflow.com/a/66210557/7723666)